### PR TITLE
Add an LSB stanza (for Debian and Ubuntu boot fikle ordering)

### DIFF
--- a/ossec-hids-agent-2.8.0/debian/ossec-hids-agent.init
+++ b/ossec-hids-agent-2.8.0/debian/ossec-hids-agent.init
@@ -2,9 +2,24 @@
 # OSSEC	        Controls OSSEC HIDS
 # Author:       Daniel B. Cid <dcid@ossec.net>
 # Modified for slackware by Jack S. Lai
+### BEGIN INIT INFO
+# Provides:          ossec
+# Required-Start:    $network
+# Required-Stop:     $network
+# Default-Start:     2 3 5
+# Default-Stop:      0 6
+# Description: OSSEC SIEM
+# short-description: OSSEC SIEM
+### END INIT INFO
 
 
 . /etc/ossec-init.conf
+[ -f /etc/default/ossec ] && . /etc/default/ossec
+
+if [ "X${OSSEC_ENABLE}" = "Xno" ]; then
+    exit 0
+fi
+
 if [ "X${DIRECTORY}" = "X" ]; then
     DIRECTORY="/var/ossec"
 fi

--- a/ossec-hids-hybrid-2.8.0/debian/ossec-hids-hybrid.init
+++ b/ossec-hids-hybrid-2.8.0/debian/ossec-hids-hybrid.init
@@ -2,9 +2,24 @@
 # OSSEC	        Controls OSSEC HIDS
 # Author:       Daniel B. Cid <dcid@ossec.net>
 # Modified for slackware by Jack S. Lai
+### BEGIN INIT INFO
+# Provides:          ossec
+# Required-Start:    $network
+# Required-Stop:     $network
+# Default-Start:     2 3 5
+# Default-Stop:      0 6
+# Description: OSSEC SIEM
+# short-description: OSSEC SIEM
+### END INIT INFO
 
 
 . /etc/ossec-init.conf
+[ -f /etc/default/ossec ] && . /etc/default/ossec
+
+if [ "X${OSSEC_ENABLE}" = "Xno" ]; then
+    exit 0
+fi
+
 if [ "X${DIRECTORY}" = "X" ]; then
     DIRECTORY="/var/ossec"
 fi

--- a/ossec-hids-local-2.8.0/debian/ossec-hids-local.init
+++ b/ossec-hids-local-2.8.0/debian/ossec-hids-local.init
@@ -2,9 +2,24 @@
 # OSSEC	        Controls OSSEC HIDS
 # Author:       Daniel B. Cid <dcid@ossec.net>
 # Modified for slackware by Jack S. Lai
+### BEGIN INIT INFO
+# Provides:          ossec
+# Required-Start:    $network
+# Required-Stop:     $network
+# Default-Start:     2 3 5
+# Default-Stop:      0 6
+# Description: OSSEC SIEM
+# short-description: OSSEC SIEM
+### END INIT INFO
 
 
 . /etc/ossec-init.conf
+[ -f /etc/default/ossec ] && . /etc/default/ossec
+
+if [ "X${OSSEC_ENABLE}" = "Xno" ]; then
+    exit 0
+fi
+
 if [ "X${DIRECTORY}" = "X" ]; then
     DIRECTORY="/var/ossec"
 fi

--- a/ossec-hids-server-2.8.0/debian/ossec-hids-server.init
+++ b/ossec-hids-server-2.8.0/debian/ossec-hids-server.init
@@ -2,9 +2,24 @@
 # OSSEC	        Controls OSSEC HIDS
 # Author:       Daniel B. Cid <dcid@ossec.net>
 # Modified for slackware by Jack S. Lai
+### BEGIN INIT INFO
+# Provides:          ossec
+# Required-Start:    $network
+# Required-Stop:     $network
+# Default-Start:     2 3 5
+# Default-Stop:      0 6
+# Description: OSSEC SIEM
+# short-description: OSSEC SIEM
+### END INIT INFO
 
 
 . /etc/ossec-init.conf
+[ -f /etc/default/ossec ] && . /etc/default/ossec
+
+if [ "X${OSSEC_ENABLE}" = "Xno" ]; then
+    exit 0
+fi
+
 if [ "X${DIRECTORY}" = "X" ]; then
     DIRECTORY="/var/ossec"
 fi


### PR DESCRIPTION
Allow for disabling OSSEC on installation. This can be done by creating a /etc/default/ossec file
with OSSEC_ENABLE=no in it. This is to prevent the case where installing OSSEC with a default config locks out the person remotely configuring OSSEC (been there, done that, got the t-shirt :-)

Also, add an LSB stanza to make sure Debian and Ubuntu use proper sequencing in /etc/init.d.
